### PR TITLE
Normalize MS map_ BIF names and document grammar.

### DIFF
--- a/erts/doc/src/match_spec.xml
+++ b/erts/doc/src/match_spec.xml
@@ -132,11 +132,18 @@
         <c><![CDATA['/=']]></c> | <c><![CDATA[self]]></c> |
         <c><![CDATA[get_tcw]]></c>
       </item>
-      <item>MatchBody ::= [ ActionTerm ]
+      <item>MatchBody ::= [ BodyTerm, ... ]
       </item>
-      <item>ActionTerm ::= ConditionExpression | ActionCall
+      <item>BodyTerm ::= BodyExpression | ActionCall
       </item>
-      <item>ActionCall ::= {ActionFunction} | {ActionFunction, ActionTerm, ...}
+      <item>BodyExpression ::= ExprMatchVariable | { BodyFunction } |
+        { BodyFunction, ConditionExpression, ... } | TermConstruct
+      </item>
+      <item>BodyFunction ::= GuardFunction |
+        <c><![CDATA[map_put]]></c> |
+        <c><![CDATA[map_remove]]></c>
+      </item>
+      <item>ActionCall ::= {ActionFunction} | {ActionFunction, BodyTerm, ...}
       </item>
       <item>ActionFunction ::= <c><![CDATA[set_seq_token]]></c> |
         <c><![CDATA[get_seq_token]]></c> | <c><![CDATA[message]]></c> |
@@ -219,7 +226,14 @@
         <c><![CDATA['==']]></c> | <c><![CDATA['=/=']]></c> |
         <c><![CDATA['/=']]></c> | <c><![CDATA[self]]></c>
       </item>
-      <item>MatchBody ::= [ ConditionExpression, ... ]
+      <item>MatchBody ::= [ BodyExpression, ... ]
+      </item>
+      <item>BodyExpression ::= ExprMatchVariable | { BodyFunction } |
+        { BodyFunction, ConditionExpression, ... } | TermConstruct
+      </item>
+      <item>BodyFunction ::= GuardFunction |
+        <c><![CDATA[map_put]]></c> |
+        <c><![CDATA[map_remove]]></c>
       </item>
     </list>
   </section>
@@ -296,11 +310,18 @@
           <c>'=:='</c>, <c>'=='</c>, <c>'=/='</c>, <c>'/='</c>,
           <c>self</c></tag>
         <item>
-          <p>Same as the corresponding Erlang BIFs (or operators). In case of
+          <p>Same as the corresponding Erlang BIFs (or operators),
+            allowed in both match guards and match bodies. In case of
             bad arguments, the result depends on the context. In the
             <c><![CDATA[MatchConditions]]></c> part of the expression, the test
             fails immediately (like in an Erlang guard). In the
             <c><![CDATA[MatchBody]]></c> part, exceptions are implicitly caught
+            and the call results in the atom <c><![CDATA['EXIT']]></c>.</p>
+        </item>
+        <tag><c>map_put</c>, <c>map_remove</c>
+        <item>
+          <p>Same as the corresponding Erlang maps functions,
+            only allowed in match bodies. Exceptions are implicitly caught
             and the call results in the atom <c><![CDATA['EXIT']]></c>.</p>
         </item>
       </taglist>

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -416,8 +416,8 @@ atom Lt='<'
 atom machine
 atom magic_ref
 atom major
-atom maps_put
-atom maps_remove
+atom map_put
+atom map_remove
 atom match
 atom match_limit
 atom match_limit_recursion

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -60,6 +60,8 @@
 #define DBIF_TRACE_BODY  (1 << (DCOMP_TRACE + DBIF_BODY))
 #define DBIF_ALL \
 DBIF_TABLE_GUARD | DBIF_TABLE_BODY | DBIF_TRACE_GUARD | DBIF_TRACE_BODY
+#define DBIF_ALL_BODY \
+DBIF_TABLE_BODY | DBIF_TRACE_BODY
 
 
 #define HEAP_XTRA 100
@@ -697,16 +699,16 @@ static DMCGuardBif guard_tab[] =
         DBIF_ALL
     },
     {
-        am_maps_put,
+        am_map_put,
         &maps_put_3,
         3,
-        DBIF_TABLE_BODY
+        DBIF_ALL_BODY
     },
     {
-        am_maps_remove,
+        am_map_remove,
         &maps_remove_2,
         2,
-        DBIF_TABLE_BODY
+        DBIF_ALL_BODY
     },
     {
         am_is_map_key,

--- a/lib/stdlib/src/ms_transform.erl
+++ b/lib/stdlib/src/ms_transform.erl
@@ -1001,6 +1001,10 @@ pseudo_guard_function(_,_) -> false.
 guard_function(X,A) ->
     real_guard_function(X,A) or pseudo_guard_function(X,A).
 
+body_function(map_put,3) -> true;
+body_function(map_remove,2) -> true;
+body_function(_,_) -> false.
+
 action_function(set_seq_token,2) -> true;
 action_function(get_seq_token,0) -> true;
 action_function(message,1) -> true;
@@ -1020,8 +1024,6 @@ action_function(trace,3) -> true;
 action_function(caller_line,0) -> true;
 action_function(current_stacktrace,0) -> true;
 action_function(current_stacktrace,1) -> true;
-action_function(maps_put,3) -> true;
-action_function(maps_remove,2) -> true;
 action_function(_,_) -> false.
 
 bool_operator('and',2) ->
@@ -1097,7 +1099,7 @@ is_imported_from_erlang(X,A,_) ->
     arith_operator(X,A) or cmp_operator(X,A).
 
 is_ms_function(X,A,body) ->
-    action_function(X,A) or guard_function(X,A) or bool_test(X,A);
+    action_function(X,A) or body_function(X,A) or guard_function(X,A) or bool_test(X,A);
 
 is_ms_function(X,A,guard) ->
     guard_function(X,A) or bool_test(X,A).


### PR DESCRIPTION
Picked up and played with https://github.com/erlang/otp/pull/7326 a little @sverker, here's a PR form of [some of my thoughts](https://github.com/erlang/otp/pull/7326#issuecomment-1939307450).

- Renames `maps_put` and `maps_remove` to `map_put` and `map_remove`

    The reasoning being:

    - The pre-existing `map_get` call allowed in matchspecs today is singular
    - This is to mirror the auto-imported `map_get` BIF in the `erlang` module; in the future if map put/remove BIFs are added to `erlang` they would be named similarly too
      - _I'm [playing with this](https://github.com/christhekeele/otp/commit/70f3d9d4ad582b10d7b208559755634aa768d7c8) a little, but very out of my depth_

- Allows `map_put` and `map_remove` in trace matchspec bodies

    - I think we may as well allow modification of maps used in tracing; ex. adding some sort of metadata into a map being used as an emitted `message` in certain trace patterns

- Separates these functions from action functions in both documentation and implementation

- Updates the matchspec grammar docs